### PR TITLE
Update contribution guidelines

### DIFF
--- a/insulin_resistance_prediction/CONTRIBUTING.md
+++ b/insulin_resistance_prediction/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# How to Contribute
+
+We are not accepting external pull requests at this time. Please
+[file an issue](https://github.com/Google-Health/consumer-health-research/issues)
+if you encounter any bugs.
+
+## Contributor License Agreement
+
+Contributions to this project must be accompanied by a Contributor License
+Agreement (CLA). You (or your employer) retain the copyright to your
+contribution; this simply gives us permission to use and redistribute your
+contributions as part of the project. Head over to
+<https://cla.developers.google.com/> to see your current agreements on file or
+to sign a new one.
+
+You generally only need to submit a CLA once, so if you've already submitted one
+(even if it was for a different project), you probably don't need to do it
+again.
+
+## Code Reviews
+
+We are not accepting external pull requests at this time.
+
+All submissions require review. We use GitHub pull requests for this purpose. Consult
+[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
+information on using pull requests.
+
+## Community Guidelines
+
+This project follows
+[Google's Open Source Community Guidelines](https://opensource.google/conduct/).

--- a/insulin_resistance_prediction/README.md
+++ b/insulin_resistance_prediction/README.md
@@ -69,7 +69,8 @@ by running `!pip install <package>` in a new cell.
 
 ## Contributing
 
-For details on contributing to this repository, please see [CONTRIBUTING.md](https://github.com/Google-Health/consumer-health-research/blob/main/CONTRIBUTING.md).
+Currently we do not accept external contributions to this repository. For more details, please see
+[CONTRIBUTING.md](https://github.com/Google-Health/consumer-health-research/tree/main/insulin_resistance_prediction/CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
Summary of changes

- add `insulin_resistance_prediction/CONTRIBUTING.md` file with this folder's contribution policy.
- update `insulin_resistance_prediction/README.md` to reference the new file and explicitly state we do not accept external contributions at the moment.