### PR TITLE
Add rppg placeholder directory to fix 404

### DIFF
--- a/rppg/README.md
+++ b/rppg/README.md
@@ -1,0 +1,5 @@
+# rPPG (Remote Photoplethysmography) Research
+
+> 📢 **Status: To be updated**
+> 
+> The code, models, and documentation for our rPPG research are currently being prepared and will be published here soon. Please check back later!


### PR DESCRIPTION
Adds a temporary rppg directory and README placeholder to prevent the tree link from returning a 404 error until the official code is ready.